### PR TITLE
make final stage of docker build from scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w' -o hello-osiris *.go
 
-FROM alpine:3.8
+FROM scratch
 COPY --from=builder /app/hello-osiris /bin/hello-osiris
 ENTRYPOINT ["/bin/hello-osiris"]


### PR DESCRIPTION
This makes the image even smaller. Smaller == better for Osiris-enabled apps.